### PR TITLE
HMGET command does not work because of parameter problem

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -199,7 +199,10 @@ func HGet(RConn *redigo.Conn, key string, HKey string) (interface{}, error) {
 }
 
 func HMGet(RConn *redigo.Conn, key string, hashKeys ...string) ([]interface{}, error) {
-	ret, err := (*RConn).Do(REDIS_KEYWORD_HMGET, key, hashKeys)
+	args := []interface{}{key}
+	args = append(args, hashKeys)
+
+	ret, err := (*RConn).Do(REDIS_KEYWORD_HMGET, args)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
func Do need a interface{} slice, not a string and a []interface{}. If input k1,f1,f2, hmget get [k1, [f1, f2]], this is not work, hmget need [k1, f1, f2].